### PR TITLE
libjpeg-turbo: add config to disable merged upsample

### DIFF
--- a/jdapimin.c
+++ b/jdapimin.c
@@ -204,6 +204,7 @@ default_decompress_parms(j_decompress_ptr cinfo)
   cinfo->raw_data_out = FALSE;
   cinfo->dct_method = JDCT_DEFAULT;
   cinfo->do_fancy_upsampling = TRUE;
+  cinfo->disable_merged_upsampling = FALSE;
   cinfo->do_block_smoothing = TRUE;
   cinfo->quantize_colors = FALSE;
   /* We set these in case application only sets quantize_colors. */

--- a/jdmaster.c
+++ b/jdmaster.c
@@ -35,7 +35,7 @@ use_merged_upsample(j_decompress_ptr cinfo)
 {
 #ifdef UPSAMPLE_MERGING_SUPPORTED
   /* Merging is the equivalent of plain box-filter upsampling */
-  if (cinfo->do_fancy_upsampling || cinfo->CCIR601_sampling)
+  if (cinfo->do_fancy_upsampling || cinfo->CCIR601_sampling || cinfo->disable_merged_upsampling)
     return FALSE;
   /* jdmerge.c only supports YCC=>RGB and YCC=>RGB565 color conversion */
   if (cinfo->jpeg_color_space != JCS_YCbCr || cinfo->num_components != 3 ||

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -704,6 +704,8 @@ struct jpeg_decompress_struct {
   struct jpeg_upsampler *upsample;
   struct jpeg_color_deconverter *cconvert;
   struct jpeg_color_quantizer *cquantize;
+
+  boolean disable_merged_upsampling;  /* FALSE=Do not disable merged upsampling */
 };
 
 


### PR DESCRIPTION
Add a configuration switch, disable_merged_upsampling, so that user can
choose to disable merged upsampling. The default value is FALSE. To
disable merged upsampling, user needs to set disable_merged_upsampling to
TRUE before calling jpeg_start_decompress().

Change-Id: Ic36e2264c69138fd72760c98a0bb6ed44704e453
Signed-off-by: mydongistiny <jaysonedson@gmail.com>